### PR TITLE
Add level name for stage RTAs in the queue list.

### DIFF
--- a/src/components/Run.tsx
+++ b/src/components/Run.tsx
@@ -14,7 +14,8 @@ interface Props {
 
 const Card = styled.a`
   ${({ theme }) => css`
-    width: 600px;
+    min-width: 600px;
+    max-width: 800px;
     margin: 10px 0;
     padding: 10px 30px 10px 10px;
     border-radius: 5px;
@@ -67,10 +68,14 @@ export const Run: React.FC<Props> = ({ runDoc, gameDoc }) => {
 
   const run = useMemo(() => {
     const category = game?.categories[unmappedRun.category].name;
+    const level = unmappedRun.level
+      ? game?.levels[unmappedRun.level]?.name
+      : null;
 
     return {
       ...unmappedRun,
       category,
+      level,
       time: formatDuration(unmappedRun.time),
     };
   }, [unmappedRun, game]);
@@ -135,7 +140,9 @@ export const Run: React.FC<Props> = ({ runDoc, gameDoc }) => {
       <CardContent>
         <CardRow>
           <p>
-            {run.category} in {run.time} by {run.runner}
+            {run.category}
+            {run.level ? <> ({run.level})</> : null} in {run.time} by{" "}
+            {run.runner}
             {run.videos.length === 0 && " (no video)"}
           </p>
           <p>Submitted {formatDistanceToNow(run.submitted.toDate())} ago</p>

--- a/src/types/firestore.ts
+++ b/src/types/firestore.ts
@@ -12,6 +12,7 @@ export interface RunDoc {
   id: string;
   status: "new" | "verified" | "rejected";
   category: string;
+  level?: string | null;
   time: string;
   submitted: Timestamp;
   runner: string;
@@ -36,6 +37,11 @@ export interface GameDoc {
   srcomId: string;
   categories: {
     [categoryId: string]: {
+      name: string;
+    };
+  };
+  levels: {
+    [levelId: string]: {
       name: string;
     };
   };

--- a/src/types/srcom.ts
+++ b/src/types/srcom.ts
@@ -13,6 +13,7 @@ export interface ApiRun {
   // If a run is rejected, then all we have to go off of is the submitted datetime
   submitted: string;
   category: string;
+  level?: string | null;
   times: {
     realtime: string;
     ingame: string;
@@ -72,10 +73,18 @@ interface ApiVariable {
   };
 }
 
+export interface ApiLevel {
+  id: string;
+  name: string;
+}
+
 export interface ApiGame {
   id: string;
   names: {
     international: string;
+  };
+  levels: {
+    data: ApiLevel[];
   };
   categories: {
     data: ApiCategory[];

--- a/src/util/srcom.ts
+++ b/src/util/srcom.ts
@@ -51,6 +51,7 @@ function mapApiRun(apiRun: ApiRun): RunDoc {
     status: apiRun.status.status,
     runner: apiRun.players.data[0].names.international,
     category: apiRun.category, // TODO
+    level: apiRun.level,
     time: apiRun.times.realtime,
     submitted: Timestamp.fromDate(new Date(apiRun.submitted)),
     platform: apiRun.system.platform, // TODO
@@ -129,6 +130,12 @@ function mapApiGame(apiGame: ApiGame): GameDoc {
       },
       {}
     ),
+    levels: apiGame.levels.data.reduce<GameDoc["levels"]>((acc, curr) => {
+      acc[curr.id] = {
+        name: curr.name,
+      };
+      return acc;
+    }, {}),
     platforms: apiGame.platforms.data.reduce<GameDoc["platforms"]>(
       (acc, curr) => {
         acc[curr.id] = {
@@ -174,7 +181,7 @@ export async function getGame(abbreviation: string): Promise<GameDoc> {
     const response = await axios.get<{ data: [ApiGame] }>(`${API_BASE}/games`, {
       params: {
         abbreviation,
-        embed: "categories,platforms,regions,variables",
+        embed: "categories,platforms,regions,variables,levels",
       },
     });
 


### PR DESCRIPTION
This pull requests adds the level for which a Stage RTA was submitted in the queue list.

Previously, line would look like this

> Stage RTA in 5:00 by runner

After this change, the line will look like this:

> Stage RTA (Whomps Fortress) in 5:00 by runner

The changes fetch the level data from the game info (refreshed once a day) and the level from each run (null when unset), parses that information out and displays it. The row of runs has been allowed to expand 200px more to help keep all the information on one line on screen that can allow it.
