### PR TITLE
Improve run duration displaying when sub 10 minutes/seconds is used.

### DIFF
--- a/src/util/duration.ts
+++ b/src/util/duration.ts
@@ -14,7 +14,7 @@ export function formatDuration(isoDuration: string): string {
     minutes = `0${minutes}`;
   }
 
-  let seconds = `${parsedSeconds}`;
+  let seconds = String(parsedSeconds);
   if (parsedSeconds < 10) {
     seconds = `0${seconds}`;
   }

--- a/src/util/duration.ts
+++ b/src/util/duration.ts
@@ -3,20 +3,20 @@ import { parse } from "tinyduration";
 export function formatDuration(isoDuration: string): string {
   const parsedTime = parse(isoDuration);
 
-  const hours = parsedTime.hours ? `${parsedTime.hours}:` : "";
-  let minutes = "0:";
-  if (parsedTime.minutes) {
-    minutes = `${parsedTime.minutes}:`;
-    if (parsedTime.hours && parsedTime.minutes < 10) {
-      minutes = `0${minutes}`;
-    }
+  const parsedHours = parsedTime.hours || 0;
+  const parsedMinutes = parsedTime.minutes || 0;
+  const parsedSeconds = parsedTime.seconds || 0;
+
+  const hours = parsedHours ? `${parsedHours}:` : "";
+
+  let minutes = `${parsedMinutes}:`;
+  if (parsedHours && parsedMinutes < 10) {
+    minutes = `0${minutes}`;
   }
-  let seconds = "00";
-  if (parsedTime.seconds) {
-    seconds = String(parsedTime.seconds);
-    if (parsedTime.minutes && parsedTime.seconds < 10) {
-      seconds = `0${seconds}`;
-    }
+
+  let seconds = `${parsedSeconds}`;
+  if (parsedSeconds < 10) {
+    seconds = `0${seconds}`;
   }
 
   return `${hours}${minutes}${seconds}`;


### PR DESCRIPTION
Example: 2 hours flat run would be displayed 2:0:00 instead of 2:00:00 in the list of runs. This change fixes this issue.